### PR TITLE
Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # The project is in development
 
 `slate-devtools` as name suggests it is devtool for [slatejs](https://github.com/ianstormtaylor/slate) which will assist you in debugging the code
@@ -8,16 +7,16 @@ To know about features take loot at this [issue](https://github.com/ianstormtayl
 # Features
 
 Currently working on finishing these tasks
-- [X] Provide some feedback on current state in `RenderHistory` 
-- [ ] Differentiate between operations happened in devtools and operations happened in app
-- [ ] Update the working of `AppOperations` so that every single of batch of operations will not be considered as single operation
+
+- [x] Provide some feedback on current state in `RenderHistory`
+- [x] Differentiate between operations happened in devtools and operations happened in app
+- [x] Update the working of `AppOperations` so that every single of batch of operations will not be considered as single operation
 - [ ] Add a cleanup function so that unnecessary operations in `RenderHistory` will not be shown
 - [ ] Create a plugin that can be used in creating the app `editor`. It should give a lot more important information about app operations like weather an operation is due to normalization.
 
-
 # Roadmap
 
-- [X] Release the tool in npm
+- [x] Release the tool in npm
 - [ ] Features
 - [ ] Improve the look
 - [ ] Write tests

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently working on finishing these tasks
 - [x] Provide some feedback on current state in `RenderHistory`
 - [x] Differentiate between operations happened in devtools and operations happened in app
 - [x] Update the working of `AppOperations` so that every single of batch of operations will not be considered as single operation
-- [ ] Add a cleanup function so that unnecessary operations in `RenderHistory` will not be shown
+- [x] Add a cleanup function so that unnecessary operations in `RenderHistory` will not be shown
 - [ ] Create a plugin that can be used in creating the app `editor`. It should give a lot more important information about app operations like weather an operation is due to normalization.
 
 # Roadmap

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Currently working on finishing these tasks
 - [x] Differentiate between operations happened in devtools and operations happened in app
 - [x] Update the working of `AppOperations` so that every single of batch of operations will not be considered as single operation
 - [x] Add a cleanup function so that unnecessary operations in `RenderHistory` will not be shown
-- [ ] Create a plugin that can be used in creating the app `editor`. It should give a lot more important information about app operations like weather an operation is due to normalization.
 
 # Roadmap
 
 - [x] Release the tool in npm
-- [ ] Features
+- [x] Features
+- [ ] Write a plugin that users can use to provide lot more information about `App Operations`
 - [ ] Improve the look
 - [ ] Write tests
 - [ ] Add support for multiple editors

--- a/slate-devtools/src/components/renderBatch.tsx
+++ b/slate-devtools/src/components/renderBatch.tsx
@@ -23,7 +23,7 @@ export type RenderBranchProps = {
 export const RenderBatch = ({ batch, num }: RenderBranchProps) => {
   const [showOperations, onClick] = useToggleOnClick<HTMLButtonElement>(false);
 
-  return (
+  return !(batch.location === "Devtools" && batch.normalizing) ? (
     <StyledRenderBatch>
       <StyledBatchButton
         onClick={onClick}
@@ -43,7 +43,7 @@ export const RenderBatch = ({ batch, num }: RenderBranchProps) => {
           })
         : null}
     </StyledRenderBatch>
-  );
+  ) : null;
 };
 
 const StyledBatchButton = styled("button", {

--- a/slate-devtools/src/devtools/updateButtons.tsx
+++ b/slate-devtools/src/devtools/updateButtons.tsx
@@ -109,7 +109,7 @@ export const UpdateButtons = ({ editor, value, devValue }: Props) => {
    */
   useEffect(() => {
     const { current } = appOperations;
-
+    console.log(current);
     if (current.length !== 0 && updateDevtools !== "on") {
       setUpdateDevtools("on");
     } else if (current.length === 0 && updateDevtools !== "off") {

--- a/slate-devtools/src/devtools/updateButtons.tsx
+++ b/slate-devtools/src/devtools/updateButtons.tsx
@@ -109,7 +109,6 @@ export const UpdateButtons = ({ editor, value, devValue }: Props) => {
    */
   useEffect(() => {
     const { current } = appOperations;
-    console.log(current);
     if (current.length !== 0 && updateDevtools !== "on") {
       setUpdateDevtools("on");
     } else if (current.length === 0 && updateDevtools !== "off") {

--- a/slate-devtools/src/devtools/updateButtons.tsx
+++ b/slate-devtools/src/devtools/updateButtons.tsx
@@ -10,6 +10,11 @@ import { applyOperations } from "../util/applyOperations";
 import { inverseOperations } from "../util/inverseOperations";
 import { Button } from "../components/button/button";
 import { styled } from "../styles/stitches.config";
+import { Batch } from "../util/historyEditor";
+import { addBatchOperations } from "../util/addBatchOperations";
+import { applyBatchOperations } from "../util/applyBatchOperations";
+import { nanoid } from "nanoid";
+import { inverseBatchOperations } from "../util/inverseBatchOperations";
 
 type Props = {
   editor: ReactEditor;
@@ -36,7 +41,7 @@ export const UpdateButtons = ({ editor, value, devValue }: Props) => {
   /**
    * Stores every operation applied to app (editor)
    */
-  const appOperations = useRef<Operation[]>([]);
+  const appOperations = useRef<Batch[]>([]);
 
   /**
    * stores every operation applied to devtools (devEditor)
@@ -67,7 +72,14 @@ export const UpdateButtons = ({ editor, value, devValue }: Props) => {
       return;
     }
 
-    appOperations.current = addOperations(appOperations, editor.operations);
+    appOperations.current = addBatchOperations(
+      appOperations,
+      editor.operations,
+      {
+        location: "App",
+        normalizing: false,
+      }
+    );
   }, [value, editor.operations]);
 
   /**
@@ -111,7 +123,6 @@ export const UpdateButtons = ({ editor, value, devValue }: Props) => {
    */
   useEffect(() => {
     const { current } = devtoolsOperations;
-
     if (current.length !== 0) {
       setUpdateApp("on");
       clickUpdateAppButtonOnce();
@@ -137,23 +148,28 @@ export const UpdateButtons = ({ editor, value, devValue }: Props) => {
     e.preventDefault();
 
     isDevtoolsUpdating.current = true;
-    const operations: Operation[] = [];
+    const operations: Batch[] = [];
 
     if (updateApp === "on") {
+      const inverseOperation: Batch = {
+        data: [],
+        id: nanoid(),
+        location: "Devtools",
+        normalizing: false,
+      };
       for (const operation of inverseOperations(devtoolsOperations.current)) {
-        operations.push(operation);
+        inverseOperation.data.push(operation);
       }
       devtoolsOperations.current = [];
+
+      if (inverseOperation.data.length !== 0) {
+        operations.push(inverseOperation);
+      }
     }
 
-    appOperations.current = applyOperations(
+    appOperations.current = applyBatchOperations(
       operations.concat(appOperations.current),
-      devEditor,
-      /**
-       * Specify the location of operation as App
-       */
-
-      { location: "App" }
+      devEditor
     );
   };
 
@@ -177,7 +193,7 @@ export const UpdateButtons = ({ editor, value, devValue }: Props) => {
     const operations: Operation[] = [];
 
     if (updateDevtools === "on") {
-      for (const operation of inverseOperations(appOperations.current)) {
+      for (const operation of inverseBatchOperations(appOperations.current)) {
         operations.push(operation);
       }
       appOperations.current = [];

--- a/slate-devtools/src/plugins/withHistory.tsx
+++ b/slate-devtools/src/plugins/withHistory.tsx
@@ -144,7 +144,10 @@ export const withHistory = <T extends Editor>(editor: T) => {
  * Copied from slate-history
  */
 
-const shouldMerge = (op: Operation, prev: Operation | undefined): boolean => {
+export const shouldMerge = (
+  op: Operation,
+  prev: Operation | undefined
+): boolean => {
   if (
     prev &&
     op.type === "insert_text" &&

--- a/slate-devtools/src/plugins/withHistory.tsx
+++ b/slate-devtools/src/plugins/withHistory.tsx
@@ -22,7 +22,7 @@ export const withHistory = <T extends Editor>(editor: T) => {
   e.isNormalizing = false; // Says weather an operation is due to normalizing
   e.shouldNormalize = true; // Says weather we should normalize after that operation
   e.from = undefined; // Stores the current state in History
-
+  e.dontMerge = false;
   e.normalizeNode = (entry) => {
     if (e.shouldNormalize) {
       e.isNormalizing = true;
@@ -74,7 +74,7 @@ export const withHistory = <T extends Editor>(editor: T) => {
       e.history = HistoryEditor.giveTill(e, from);
     }
 
-    const { operations, history, isNormalizing } = e;
+    const { operations, history, isNormalizing, dontMerge } = e;
 
     /**
      * Most of the code below is copied from slate-history there are 
@@ -87,19 +87,21 @@ export const withHistory = <T extends Editor>(editor: T) => {
     const lastOp = lastBatch && lastBatch.data[lastBatch.data.length - 1];
     let merge = false;
 
-    if (!lastBatch) {
-      merge = false;
-    } else if (lastBatch.normalizing !== isNormalizing) {
-      /**
-       * If the lastBatch normalizing is not equal to current isNormalizing then
-       * we wont merge those operations
-       */
+    if (!dontMerge) {
+      if (!lastBatch) {
+        merge = false;
+      } else if (lastBatch.normalizing !== isNormalizing) {
+        /**
+         * If the lastBatch normalizing is not equal to current isNormalizing then
+         * we wont merge those operations
+         */
 
-      merge = false;
-    } else if (operations.length !== 0) {
-      merge = true;
-    } else {
-      merge = shouldMerge(op, lastOp);
+        merge = false;
+      } else if (operations.length !== 0) {
+        merge = true;
+      } else {
+        merge = shouldMerge(op, lastOp);
+      }
     }
 
     if (lastBatch && merge) {

--- a/slate-devtools/src/util/addBatchOperations.tsx
+++ b/slate-devtools/src/util/addBatchOperations.tsx
@@ -1,6 +1,6 @@
 import { nanoid } from "nanoid";
 import { Operation } from "slate";
-import { addOperations } from "./addOperations";
+import { shouldMerge } from "../plugins";
 import { Batch } from "./historyEditor";
 
 /**
@@ -16,19 +16,35 @@ export const addBatchOperations = (
   } = {}
 ) => {
   const { normalizing = false, location = "Devtools" } = options;
-
   const { current } = ref;
 
-  const newBatch: Batch = {
-    normalizing,
-    location,
-    id: nanoid(),
-    data: addOperations({ current: [] }, operations),
-  };
+  for (const op of operations) {
+    if (op.type === "set_selection") {
+      continue;
+    }
 
-  if (newBatch.data.length !== 0) {
-    current.push(newBatch);
+    const lastBatch = current[current.length - 1] as Batch | undefined;
+    const lastOp = lastBatch && lastBatch.data[lastBatch.data.length - 1];
+    let merge = false;
+
+    if (operations.length !== 0) {
+      merge = true;
+    } else if (shouldMerge(op, lastOp)) {
+      merge = true;
+    }
+
+    if (lastBatch && merge) {
+      lastBatch.data.push(op);
+    } else {
+      const newBatch: Batch = {
+        normalizing,
+        location,
+        id: nanoid(),
+        data: [op],
+      };
+
+      current.push(newBatch);
+    }
   }
-
   return current;
 };

--- a/slate-devtools/src/util/addBatchOperations.tsx
+++ b/slate-devtools/src/util/addBatchOperations.tsx
@@ -1,0 +1,34 @@
+import { nanoid } from "nanoid";
+import { Operation } from "slate";
+import { addOperations } from "./addOperations";
+import { Batch } from "./historyEditor";
+
+/**
+ * Adds group of operations as Batch Operation
+ */
+
+export const addBatchOperations = (
+  ref: { current: Batch[] },
+  operations: Operation[],
+  options: {
+    normalizing?: boolean;
+    location?: "App" | "Devtools";
+  } = {}
+) => {
+  const { normalizing = false, location = "Devtools" } = options;
+
+  const { current } = ref;
+
+  const newBatch: Batch = {
+    normalizing,
+    location,
+    id: nanoid(),
+    data: addOperations({ current: [] }, operations),
+  };
+
+  if (newBatch.data.length !== 0) {
+    current.push(newBatch);
+  }
+
+  return current;
+};

--- a/slate-devtools/src/util/applyBatchOperations.tsx
+++ b/slate-devtools/src/util/applyBatchOperations.tsx
@@ -1,0 +1,31 @@
+import { Editor } from "slate";
+import { ReactEditor } from "slate-react";
+import { Batch, HistoryEditor } from "./historyEditor";
+/**
+ * Applies a batch of operations without normalizing in between but also making sure in HistoryEditor
+ * Operation will be reflected as Seperate Batches
+ */
+
+export const applyBatchOperations = (
+  operations: Batch[],
+  editor: ReactEditor & HistoryEditor
+) => {
+  operations.forEach((batch) => {
+    const { data, location, normalizing } = batch;
+    editor.isNormalizing = normalizing;
+
+    Editor.withoutNormalizing(editor, () => {
+      data.forEach((op, i) => {
+        if (i === 0) {
+          editor.dontMerge = true;
+        } else {
+          editor.dontMerge = false;
+        }
+        editor.apply(op, { location });
+      });
+      editor.dontMerge = false;
+    });
+  });
+
+  return [];
+};

--- a/slate-devtools/src/util/historyEditor.tsx
+++ b/slate-devtools/src/util/historyEditor.tsx
@@ -17,6 +17,7 @@ export type HistoryEditor = {
     options: { shouldNormalize?: boolean; location?: "App" | "Devtools" }
   ) => void;
   from: [number, number] | undefined;
+  dontMerge: boolean;
 };
 
 type Location = [number, number];

--- a/slate-devtools/src/util/inverseBatchOperations.tsx
+++ b/slate-devtools/src/util/inverseBatchOperations.tsx
@@ -1,0 +1,22 @@
+import { Operation } from "slate";
+import { Batch } from "./historyEditor";
+import { inverseOperations } from "./inverseOperations";
+
+/**
+ * Inverses the Operations from an of Batches
+ *
+ */
+
+export const inverseBatchOperations = (batches: Batch[]) => {
+  const reverseBatch = batches.reverse();
+
+  const inverseOperation: Operation[] = [];
+
+  reverseBatch.forEach((batch) => {
+    inverseOperations(batch.data).forEach((op) => {
+      inverseOperation.push(op);
+    });
+  });
+
+  return inverseOperation;
+};


### PR DESCRIPTION
Added these features


- [x] Provide some feedback on current state in `RenderHistory`
- [x] Differentiate between operations happened in devtools and operations happened in app
- [x] Update the working of `AppOperations` so that every single of batch of operations will not be considered as single operation
- [x] Add a cleanup function so that unnecessary operations in `RenderHistory` will not be shown